### PR TITLE
Remove unused cancelHaptic from haptics module

### DIFF
--- a/src/lib/haptics.ts
+++ b/src/lib/haptics.ts
@@ -13,7 +13,6 @@ export type HapticPresetName =
 
 interface HapticsInstance {
   trigger: (input?: string) => Promise<void>
-  cancel: () => void
 }
 
 let haptics: HapticsInstance | null = null
@@ -28,8 +27,4 @@ if (typeof window !== "undefined") {
 
 export function triggerHaptic(preset: HapticPresetName = "light") {
   haptics?.trigger(preset)
-}
-
-export function cancelHaptic() {
-  haptics?.cancel()
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

`cancelHaptic` was exported from `src/lib/haptics.ts` but never imported anywhere. This change removes the dead export and drops the unused `cancel` member from the internal `HapticsInstance` type so the module surface matches actual usage.

## Verification

- `rg cancelHaptic` only matched the definition before; after removal there are no matches.
- `npm run lint` passes locally after installing dependencies.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-af1d65f5-b471-42f5-bae7-2838c72a48bd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-af1d65f5-b471-42f5-bae7-2838c72a48bd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

